### PR TITLE
switch claude-code to local binary derivation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,28 +1,9 @@
 {
   "nodes": {
-    "claude-code": {
+    "codex-cli": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1769206155,
-        "narHash": "sha256-aynUkHtmpZdwx/cqlckPOecST5J60VDIWB8eY1l5VLk=",
-        "owner": "sadjow",
-        "repo": "claude-code-nix",
-        "rev": "3156934e6e3efff4f648d679f835cf887641906f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sadjow",
-        "repo": "claude-code-nix",
-        "type": "github"
-      }
-    },
-    "codex-cli": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1768442201,
@@ -100,24 +81,6 @@
     "flake-utils": {
       "inputs": {
         "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -211,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769092226,
-        "narHash": "sha256-6h5sROT/3CTHvzPy9koKBmoCa2eJKh4fzQK8eYFEgl8=",
+        "lastModified": 1756819007,
+        "narHash": "sha256-12V64nKG/O/guxSYnr5/nq1EfqwJCdD2+cIGmhz3nrE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b579d443b37c9c5373044201ea77604e37e748c8",
+        "rev": "aaff8c16d7fc04991cac6245bee1baa31f72b1e1",
         "type": "github"
       },
       "original": {
@@ -242,22 +205,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1756819007,
-        "narHash": "sha256-12V64nKG/O/guxSYnr5/nq1EfqwJCdD2+cIGmhz3nrE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "aaff8c16d7fc04991cac6245bee1baa31f72b1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1767822896,
         "narHash": "sha256-sGq6p/R0ZtEEt9JZ/VioxaJjRJOSw0hxBPdL543Fpq8=",
         "owner": "nixos",
@@ -271,7 +218,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1767767207,
         "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
@@ -287,7 +234,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1750865895,
         "narHash": "sha256-p2dWAQcLVzquy9LxYCZPwyUdugw78Qv3ChvnX755qHA=",
@@ -306,7 +253,7 @@
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1767816572,
@@ -325,7 +272,7 @@
     "opencode": {
       "inputs": {
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1768457983,
@@ -343,34 +290,18 @@
     },
     "root": {
       "inputs": {
-        "claude-code": "claude-code",
         "codex-cli": "codex-cli",
         "darwin": "darwin",
         "home-manager": "home-manager",
         "mkalias": "mkalias",
         "nix-index-database": "nix-index-database",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "nur": "nur",
         "opencode": "opencode"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,6 @@
       url = "github:lnl7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    claude-code.url = "github:sadjow/claude-code-nix";
     codex-cli.url = "github:sadjow/codex-cli-nix";
     mkalias = {
       url = "github:reckenrode/mkalias";
@@ -39,7 +38,6 @@
     nixpkgs,
     nixos-hardware,
     home-manager,
-    claude-code,
     codex-cli,
     darwin,
     nur,
@@ -84,9 +82,6 @@
         };
         modules = [
           ./nix/darwin
-          {
-            _module.args = {inherit claude-code;};
-          }
           ({...}: {
             system.stateVersion = 4;
             system.primaryUser = "sprice";

--- a/nix/home/claude/default.nix
+++ b/nix/home/claude/default.nix
@@ -4,7 +4,6 @@
 #   /plugin marketplace add steeef/claude-hooks
 #   /plugin install <plugin>@claude-hooks
 {
-  inputs,
   pkgs,
   lib,
   ...
@@ -20,8 +19,7 @@
   # Use official home-manager claude-code module
   programs.claude-code = {
     enable = true;
-    # Use updated package from sadjow flake
-    package = inputs.claude-code.packages.${pkgs.stdenv.hostPlatform.system}.default;
+    package = pkgs.claude-code;
     # Import settings from existing JSON file
     settings = lib.importJSON ./settings.json;
     # Custom skills directory

--- a/nix/pkgs/claude-code.nix
+++ b/nix/pkgs/claude-code.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  patchelf,
+}:
+let
+  version = "2.1.19";
+  baseUrl = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
+
+  platformMap = {
+    x86_64-linux = {
+      cdnPlatform = "linux-x64";
+      hash = "sha256-Tiocc4cezzsTM3a1fe0DMzp6Y4fy0qOmJ5u5Cgf3qUQ=";
+    };
+    aarch64-linux = {
+      cdnPlatform = "linux-arm64";
+      hash = "sha256-jEthskynYNb3qi8ZcnFj0SLp/Qw86R8QaiG2kYp7G7s=";
+    };
+    x86_64-darwin = {
+      cdnPlatform = "darwin-x64";
+      hash = "sha256-viZrOpUvSD2DWK0UHir+ZhFwOGUG9Hnq2ZIxnk/cOKw=";
+    };
+    aarch64-darwin = {
+      cdnPlatform = "darwin-arm64";
+      hash = "sha256-04asj20UefhdMfNpQhyCQTXBAknDIIcBfQWl9CiFLEE=";
+    };
+  };
+
+  platform = platformMap.${stdenv.hostPlatform.system}
+    or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+assert !stdenv.hostPlatform.isMusl;
+stdenv.mkDerivation {
+  pname = "claude-code";
+  inherit version;
+
+  src = fetchurl {
+    url = "${baseUrl}/${version}/${platform.cdnPlatform}/claude";
+    hash = platform.hash;
+  };
+
+  dontUnpack = true;
+  dontFixup = true;
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    patchelf
+  ];
+
+  installPhase = ''
+    install -Dm755 $src $out/bin/claude
+  '' + lib.optionalString stdenv.hostPlatform.isLinux ''
+    patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" $out/bin/claude
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    HOME=$TMPDIR $out/bin/claude --version
+  '';
+
+  meta = {
+    description = "Anthropic's CLI for Claude AI";
+    homepage = "https://docs.anthropic.com/en/docs/claude-code";
+    license = lib.licenses.unfree;
+    mainProgram = "claude";
+    platforms = builtins.attrNames platformMap;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/nix/pkgs/claude-code.nix
+++ b/nix/pkgs/claude-code.nix
@@ -4,6 +4,17 @@
   fetchurl,
   patchelf,
 }:
+# To update:
+# 1. Set `version` to the new release version
+# 2. Update all four SRI hashes by running:
+#      VERSION="<new-version>"
+#      BASE="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+#      for plat in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+#        echo "$plat:"
+#        nix-prefetch-url --type sha256 "$BASE/$VERSION/$plat/claude" 2>/dev/null \
+#          | xargs nix hash convert --from nix32 --to sri --hash-algo sha256
+#      done
+# 3. Run `hms` to build and verify
 let
   version = "2.1.19";
   baseUrl = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -1,4 +1,5 @@
 final: prev: {
+  claude-code = final.callPackage ./claude-code.nix { };
   claude-powerline = final.callPackage ./claude-powerline.nix { };
   hidapitester = final.callPackage ./hidapitester.nix { };
   kubectl = final.callPackage ./kubectl.nix { };


### PR DESCRIPTION
## Summary
- Replace `sadjow/claude-code-nix` flake input with a self-contained Nix derivation that fetches the pre-built binary directly from Anthropic's GCS CDN
- New `nix/pkgs/claude-code.nix` supports all four platforms (x86_64/aarch64 x linux/darwin) with `dontFixup = true` to preserve the Bun payload
- Removes dead `_module.args` block from `flake.nix` and simplifies `nix/home/claude/default.nix` to use `pkgs.claude-code`

## Test plan
- [x] `nix eval` succeeds for both darwin and home-manager configurations
- [x] `hms` applies cleanly
- [x] `claude --version` outputs `2.1.19`
- [x] `which claude` resolves to Nix store path