### PR TITLE
add codegraph MCP for worktree code queries

### DIFF
--- a/nix/home/claude/default.nix
+++ b/nix/home/claude/default.nix
@@ -86,5 +86,23 @@ in {
     skills = ./skills;
     # Memory file for CLAUDE.md
     context = ./memory.md;
+
+    # CodeGraph MCP server — one-call structural queries (callers, blast radius,
+    # symbol lookup) over the ~/wt worktree Claude is working in. Darwin-only
+    # (pkgs.codegraph is macOS-only). Absolute store path so the non-login MCP
+    # subprocess resolves it without PATH. --no-watch + CODEGRAPH_NO_DAEMON keep
+    # any file watcher from leaking per ephemeral worktree; the server reconciles
+    # the index on connect instead. Usage guidance lives in memory.md.
+    mcpServers = lib.optionalAttrs pkgs.stdenv.isDarwin {
+      codegraph = {
+        type = "stdio";
+        command = "${pkgs.codegraph}/bin/codegraph";
+        args = ["serve" "--mcp" "--no-watch"];
+        env = {
+          CODEGRAPH_NO_DAEMON = "1";
+          DO_NOT_TRACK = "1";
+        };
+      };
+    };
   };
 }

--- a/nix/home/claude/memory.md
+++ b/nix/home/claude/memory.md
@@ -65,6 +65,13 @@ IMPORTANT: Update global Claude memory — edit `~/.dotfiles/nix/home/claude/mem
 - The `read_clone_warn` hook (git-worktree-hooks) warns when you Read/Grep/Glob a human clone instead of a worktree — both when a `~/wt` worktree already exists AND (≥1.5.0) on the first research read of a not-yet-worktreed repo while the `~/wt` workflow is in use (deduped per session). A cue to switch to a worktree or read `origin` via `gh api`/`gh search`; never a block. (cf94a602)
 - Done: PR (draft GitHub / open Forgejo) → `ExitWorktree` after merge.
 
+# CodeGraph — code-structure MCP (macOS; index the worktree, never the clone)
+- What: a local pre-indexed knowledge graph (`codegraph_explore`, `codegraph_node` MCP tools) answering structural questions — who-calls-X, blast-radius of Y, how-does-Z-fit — in one call. Prefer it over broad grep for those; fall back to built-in tools when it reports no index.
+- Lazy build: only when a task genuinely needs structural / blast-radius understanding (NOT every worktree, NOT surgical edits), run `codegraph init "$WORKTREE"` in the **background** — the one full parse. It writes `.codegraph/` (gitignored, disposable).
+- **Index the worktree you're in; never `codegraph init` a human clone** (read-only rule — it writes `.codegraph/` + would be stale for in-flight code). Pass `projectPath=<worktree root>` on MCP calls; don't rely on the server's cwd.
+- Freshness: automatic on a fresh session (the server reconciles the index on connect). The file watcher is disabled (`--no-watch` + `CODEGRAPH_NO_DAEMON=1`, so nothing leaks per worktree), so mid-session — after you've made significant edits and need a structural query to reflect them — run `codegraph sync "$WORKTREE"` first. Rarely needed; you already know your own edits.
+- The index persists for the worktree's life (idempotent `EnterWorktree` reuses the dir); it dies with `ExitWorktree(remove)`. No cleanup, no daemon to kill.
+
 # Docker on macOS
 - IMPORTANT: Before any docker command, check `colima status`. If not running, `colima start` and wait until ready before proceeding.
 

--- a/nix/home/claude/settings.json
+++ b/nix/home/claude/settings.json
@@ -23,7 +23,8 @@
       "Bash(prek run:*)",
       "Bash(rg:*)",
       "Bash(yamllint:*)",
-      "Bash(yq:*)"
+      "Bash(yq:*)",
+      "mcp__codegraph"
     ],
     "deny": [
       "Bash(pre-commit:*)"

--- a/nix/home/darwin/default.nix
+++ b/nix/home/darwin/default.nix
@@ -4,6 +4,7 @@
   home.packages = with pkgs; [
     bento4 # mp4decrypt — Apple Music DRM decrypt for gamdl (music tool)
     cmake
+    codegraph # local code knowledge graph (MCP); see nix/home/claude for wiring
     colima
     docker
     docker-credential-helpers
@@ -13,6 +14,15 @@
     reattach-to-user-namespace
     terminal-notifier
   ];
+
+  # CodeGraph: no detached auto-sync daemon (would leak a watcher per ephemeral
+  # ~/wt worktree; the MCP server reconciles on connect instead), and no
+  # telemetry. Inherited by interactive `codegraph` runs; the MCP server also
+  # sets these in its own env block (nix/home/claude/default.nix).
+  home.sessionVariables = {
+    CODEGRAPH_NO_DAEMON = "1";
+    DO_NOT_TRACK = "1";
+  };
 
   home.shellAliases = {
     hms = "home-manager switch --flake $HOME/.dotfiles#$USER@$(hostname)";

--- a/nix/home/git/gitignore
+++ b/nix/home/git/gitignore
@@ -28,6 +28,8 @@ TRASH/
 TRASH-FILES.md
 .claude/settings.local.json
 .claude/worktrees/
+# CodeGraph per-project index (disposable local artifact, binary SQLite)
+.codegraph/
 .claude_*.flag
 *.backup
 CLAUDE.local.md

--- a/nix/pkgs/codegraph.nix
+++ b/nix/pkgs/codegraph.nix
@@ -1,0 +1,75 @@
+# CodeGraph — pre-indexed local code knowledge graph exposed to agents over MCP.
+# Upstream ships self-contained prebuilt bundles (a vendored Node runtime + a JS
+# app + a POSIX-sh launcher) per platform on GitHub Releases; there is no source
+# build. We install the bundle verbatim and symlink its launcher, which resolves
+# symlinks back to the bundle dir itself (so `$out/bin/codegraph` just works).
+# macOS-only for now: that's where the Claude worktree workflow runs, and the
+# Linux bundle's vendored Node would need autoPatchelfHook (unverified).
+#
+# Updating to a new release — do NOT run `codegraph upgrade` (it targets the
+# installer's ~/.local/bin layout and no-ops against the read-only nix store):
+#   1. Prefetch both Darwin hashes for the new tag:
+#        V=1.3.0   # new release tag, without the leading "v"
+#        for a in darwin-arm64 darwin-x64; do \
+#          nix-prefetch-url --type sha256 \
+#            "https://github.com/colbymchenry/codegraph/releases/download/v$V/codegraph-$a.tar.gz"; \
+#        done
+#   2. Set `version` below and paste the two printed hashes into `sources`.
+#   3. `hms` — the MCP command follows automatically (it's ${pkgs.codegraph}/bin).
+# Worktree indexes are unaffected by a bump; only a DB-schema change needs a
+# re-`codegraph init` (lazy/per-worktree anyway).
+{
+  lib,
+  stdenv,
+  fetchurl,
+}: let
+  version = "1.2.0";
+  base = "https://github.com/colbymchenry/codegraph/releases/download/v${version}";
+  sources = {
+    aarch64-darwin = {
+      arch = "darwin-arm64";
+      sha256 = "0k85jqsq58x9n9dw1a5fihfqik6dp075d61agykbjsj4abffr8w3";
+    };
+    x86_64-darwin = {
+      arch = "darwin-x64";
+      sha256 = "1n4vdshw7b3s6ilip9fw5rm4h39yklq30yqys2xghrd0paczz5vg";
+    };
+  };
+  src' =
+    sources.${stdenv.hostPlatform.system}
+    or (throw "codegraph: unsupported platform ${stdenv.hostPlatform.system}");
+in
+  stdenv.mkDerivation {
+    pname = "codegraph";
+    inherit version;
+
+    src = fetchurl {
+      url = "${base}/codegraph-${src'.arch}.tar.gz";
+      inherit (src') sha256;
+    };
+
+    # Prebuilt Mach-O + JS: nothing to configure/build, and stripping would
+    # corrupt the signed vendored `node` binary.
+    dontConfigure = true;
+    dontBuild = true;
+    dontStrip = true;
+
+    # Tarball unpacks to codegraph-${arch}/ (bin/, lib/, node); install it whole
+    # and expose the launcher, which readlink-resolves back to the bundle dir.
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/libexec/codegraph" "$out/bin"
+      cp -R . "$out/libexec/codegraph/"
+      ln -s "$out/libexec/codegraph/bin/codegraph" "$out/bin/codegraph"
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Pre-indexed local code knowledge graph for AI agents (MCP)";
+      homepage = "https://github.com/colbymchenry/codegraph";
+      license = lib.licenses.mit;
+      mainProgram = "codegraph";
+      platforms = ["aarch64-darwin" "x86_64-darwin"];
+      sourceProvenance = [lib.sourceTypes.binaryNativeCode];
+    };
+  }

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -1,4 +1,5 @@
 final: prev: {
+  codegraph = final.callPackage ./codegraph.nix {};
   fgj = final.callPackage ./fgj.nix {};
   hidapitester = final.callPackage ./hidapitester.nix {};
   kubectl = final.callPackage ./kubectl.nix {};


### PR DESCRIPTION
Adopts [CodeGraph](https://github.com/colbymchenry/codegraph) — a local, pre-indexed code knowledge graph — installed via Home Manager and wired into Claude Code as an MCP server, integrated with the bare-clone/`~/wt` worktree workflow.

## What

- `nix/pkgs/codegraph.nix` — packages the self-contained prebuilt bundle (vendored Node + JS, v1.2.0) for macOS (arm64 + x64), modeled on the `kubectl.nix` prebuilt pattern. Installs the bundle whole and symlinks its launcher.
- Darwin-gated install on PATH + session vars (`CODEGRAPH_NO_DAEMON=1`, `DO_NOT_TRACK=1`).
- `programs.claude-code.mcpServers.codegraph` — registers `codegraph serve --mcp --no-watch` declaratively (verified it composes with the overridden `sadjow/claude-code-nix` package).
- Global gitignore for `.codegraph/`; worktree usage guidance in `memory.md`.

## Why this shape

Claude works in ephemeral `~/wt` worktrees and the human's clones are read-only, so the index lives in the worktree (also the tool's docs-blessed pattern). The auto-sync watcher is a detached daemon that would leak one per worktree — disabled via `--no-watch` + `CODEGRAPH_NO_DAEMON=1`; freshness comes from the server's on-connect reconciliation. Indexing is lazy (only when a task needs structural queries) so the per-worktree first-build cost is confined to worktrees that actually use it.

## Verified

- `codegraph --version` runs from the store (signed vendored Node survives the nix copy).
- Full home-config builds; generated `.mcp.json` has the correct command/args/env.
- Pre-commit clean (alejandra/deadnix/statix).

## Not yet verified (needs `hms` on the live system + a real repo)

- End-to-end: `codegraph init` in a worktree → `codegraph_explore` with `projectPath` returns structural results.
- No leaked watcher after a session (`pgrep -fl codegraph`), and whether on-connect reconcile is per-query or connect-only (determines if the mid-session `codegraph sync` note in memory.md is needed).

Updating to a new release: bump `version` + refresh both `sha256`es in `nix/pkgs/codegraph.nix`, then `hms` (recipe is in the file header). Do not use `codegraph upgrade` — no-op against the read-only nix store.